### PR TITLE
Fix MySQL download path

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2959,9 +2959,9 @@
 			<os family="mac"/>
 			<then>
 				<echo message="Downloading MySQL DB for MacOS"/>
-				<echo message="Downloading http://cdn.mysql.com/Downloads/MySQL-5.6/mysql-${demo.mysql}.tar.gz"/>
+				<echo message="Downloading http://downloads.mysql.com/archives/get/file/mysql-${demo.mysql}.tar.gz"/>
 				<exec executable="curl">
-					<arg line="-s -o '${dist}/downloads/mysql.tgz' http://cdn.mysql.com/Downloads/MySQL-5.6/mysql-${demo.mysql}.tar.gz"/>
+					<arg line="-s -o '${dist}/downloads/mysql.tgz' http://downloads.mysql.com/archives/get/file/mysql-${demo.mysql}.tar.gz"/>
 				</exec>
 			</then>
 			<else>

--- a/build.xml
+++ b/build.xml
@@ -2959,9 +2959,9 @@
 			<os family="mac"/>
 			<then>
 				<echo message="Downloading MySQL DB for MacOS"/>
-				<echo message="Downloading http://downloads.mysql.com/archives/get/file/mysql-${demo.mysql}.tar.gz"/>
+				<echo message="Downloading https://cdn.mysql.com/archives/mysql-5.6/mysql-${demo.mysql}.tar.gz"/>
 				<exec executable="curl">
-					<arg line="-s -o '${dist}/downloads/mysql.tgz' http://downloads.mysql.com/archives/get/file/mysql-${demo.mysql}.tar.gz"/>
+					<arg line="-s -o '${dist}/downloads/mysql.tgz' https://cdn.mysql.com/archives/mysql-5.6/mysql-${demo.mysql}.tar.gz"/>
 				</exec>
 			</then>
 			<else>


### PR DESCRIPTION
Getting this same error referenced in #43 (using macOS Mojave; Version 10.14.6 — master branch of this project; commit hash 664e14fa8)

```
     Installing MySQL database on MacOS
Sorry, this target couldn't be completed properly
The error message is:
The following error occurred while executing this line:
/Users/xxx/Desktop/AEM/aem-demo-machine/build.xml:2923: The following error occurred while executing this line:
/Users/xxx/Desktop/AEM/aem-demo-machine/build.xml:3400: Problem expanding gzip Not in GZIP format
```

Digging in a bit further into build.xml, it looks like lines 2962 and 2964 reference the URL:

`http://cdn.mysql.com/Downloads/MySQL-5.6/mysql-${demo.mysql}.tar.gz`

However, directly accessing http://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.41-macos10.13-x86_64.tar.gz yields a 404 not found. (Which, makes sense that a 404 error would not be in GZIP format. :))

The correct URL seems to be `http://downloads.mysql.com/archives/get/file/mysql-5.6.41-macos10.13-x86_64.tar.gz` but even after making this change, I'm still seeing the same error, so something else appears to be going on.